### PR TITLE
[PR][Chore] - 여러 개의 월별 근무표 등록하도록 수정

### DIFF
--- a/src/main/java/com/offnal/shifterz/global/exception/ErrorApiResponses.java
+++ b/src/main/java/com/offnal/shifterz/global/exception/ErrorApiResponses.java
@@ -133,6 +133,12 @@ public @interface ErrorApiResponses {
                                           "code": "CALENDAR_SHIFT_REQUIRED",
                                           "message": "근무일 정보는 필수입니다."
                                         }
+                                        """),
+                                    @ExampleObject(name = "CALENDAR_DUPLICATION", value = """
+                                        {
+                                          "code": "CALENDAR_DUPLICATION",
+                                          "message": "이미 존재하는 연도/월의 캘린더입니다."
+                                        }
                                         """)
                             }
                     ))

--- a/src/main/java/com/offnal/shifterz/global/exception/ErrorCode.java
+++ b/src/main/java/com/offnal/shifterz/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     CALENDAR_WORK_GROUP_REQUIRED(HttpStatus.BAD_REQUEST, "근무조는 필수입니다."),
     CALENDAR_WORK_TIME_REQUIRED(HttpStatus.BAD_REQUEST, "근무 시간 정보는 필수입니다."),
     CALENDAR_SHIFT_REQUIRED(HttpStatus.BAD_REQUEST, "근무일 정보는 필수입니다."),
+    CALENDAR_DUPLICATION(HttpStatus.BAD_REQUEST, "이미 존재하는 연도/월의 캘린더입니다."),
 
     //근무 관련
     WORK_INSTANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 일자에 저장된 근무 정보가 없습니다."),

--- a/src/main/java/com/offnal/shifterz/global/exception/ErrorResponse.java
+++ b/src/main/java/com/offnal/shifterz/global/exception/ErrorResponse.java
@@ -31,4 +31,10 @@ public class ErrorResponse {
         this.message = message;
         this.errors = null;
     }
+
+    public ErrorResponse(String code, String message, Map<String, String> errors) {
+        this.code = code;
+        this.message = message;
+        this.errors = errors;
+    }
 }

--- a/src/main/java/com/offnal/shifterz/kakao/KakaoLoginController.java
+++ b/src/main/java/com/offnal/shifterz/kakao/KakaoLoginController.java
@@ -5,6 +5,7 @@ import com.offnal.shifterz.global.exception.ErrorResponse;
 import com.offnal.shifterz.global.response.SuccessCode;
 import com.offnal.shifterz.global.response.SuccessResponse;
 import com.offnal.shifterz.member.dto.AuthResponseDto;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -84,6 +85,7 @@ public class KakaoLoginController {
                                     """)
                     ))
     })
+    @Hidden
     @GetMapping("/callback")
     public ResponseEntity<?> callback(@RequestParam("code") String code) {
             // 서비스 호출

--- a/src/main/java/com/offnal/shifterz/member/domain/Member.java
+++ b/src/main/java/com/offnal/shifterz/member/domain/Member.java
@@ -1,13 +1,10 @@
 package com.offnal.shifterz.member.domain;
 
-import com.offnal.shifterz.work.domain.WorkCalendar;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.util.List;
 
 @Entity
 @AllArgsConstructor
@@ -32,7 +29,7 @@ public class Member{
     @Column(name = "kakao_profile_image_url")
     private String profileImageUrl;
 
-    @OneToMany(fetch = FetchType.LAZY)
-    @JoinColumn(name = "workCalendar_id")
-    private List<WorkCalendar> workCalendars;
+//    @OneToMany(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "workCalendar_id")
+//    private List<WorkCalendar> workCalendars;
 }

--- a/src/main/java/com/offnal/shifterz/work/controller/WorkCalendarController.java
+++ b/src/main/java/com/offnal/shifterz/work/controller/WorkCalendarController.java
@@ -5,6 +5,7 @@ import com.offnal.shifterz.global.response.SuccessApiResponses;
 import com.offnal.shifterz.global.response.SuccessCode;
 import com.offnal.shifterz.global.response.SuccessResponse;
 import com.offnal.shifterz.work.dto.WorkCalendarRequestDto;
+import com.offnal.shifterz.work.dto.WorkCalendarUnitDto;
 import com.offnal.shifterz.work.dto.WorkDayResponseDto;
 import com.offnal.shifterz.work.service.WorkCalendarService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,6 +22,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+
 
 @RestController
 @RequestMapping("/works/calendar")
@@ -42,28 +44,50 @@ public class WorkCalendarController {
                     examples = @ExampleObject(
                             name = "근무표 등록 예시",
                             value = """
-                                        {
-                                          "calendarName": "병원 근무표",
-                                          "year": "2025",
-                                          "month": "7",
-                                          "workGroup": "1조",
-                                          "workTimes": {
-                                            "D": { "startTime": "08:00", "endTime": "16:00" },
-                                            "E": { "startTime": "16:00", "endTime": "00:00" },
-                                            "N": { "startTime": "00:00", "endTime": "08:00" }
-                                          },
-                                          "shifts": {
-                                            "1": "E",
-                                            "2": "E",
-                                            "3": "N",
-                                            "4": "-"
-                                          }
-                                        }
-                                        """
+                            {
+                              "calendarName": "병원 근무표",
+                              "workGroup": "1조",
+                              "workTimes": {
+                                "D": { "startTime": "08:00", "endTime": "16:00" },
+                                "E": { "startTime": "16:00", "endTime": "00:00" },
+                                "N": { "startTime": "00:00", "endTime": "08:00" }
+                              },
+                              "calendars": [
+                                {
+                                  "year": "2025",
+                                  "month": "7",
+                                  "shifts": {
+                                    "1": "E",
+                                    "2": "E",
+                                    "3": "N",
+                                    "4": "-"
+                                  }
+                                },
+                                {
+                                  "year": "2025",
+                                  "month": "8",
+                                  "shifts": {
+                                    "1": "E",
+                                    "2": "E",
+                                    "3": "N",
+                                    "4": "-"
+                                  }
+                                }
+                              ]
+                            }
+                            """
                     )
             )
     )@RequestBody @Valid WorkCalendarRequestDto workCalendarRequestDto) {
-        workCalendarService.saveWorkCalendar(workCalendarRequestDto);
+        for(WorkCalendarUnitDto unitDto : workCalendarRequestDto.getCalendars()){
+            WorkCalendarRequestDto requestDto = WorkCalendarRequestDto.builder()
+                    .calendarName(workCalendarRequestDto.getCalendarName())
+                    .workGroup(workCalendarRequestDto.getWorkGroup())
+                    .workTimes(workCalendarRequestDto.getWorkTimes())
+                    .calendars(List.of(unitDto))
+                    .build();
+            workCalendarService.saveWorkCalendar(requestDto);
+        }
         return ResponseEntity.ok(SuccessResponse.success(SuccessCode.CALENDAR_CREATED));
     }
 

--- a/src/main/java/com/offnal/shifterz/work/converter/WorkCalendarConverter.java
+++ b/src/main/java/com/offnal/shifterz/work/converter/WorkCalendarConverter.java
@@ -5,6 +5,7 @@ import com.offnal.shifterz.work.domain.WorkInstance;
 import com.offnal.shifterz.work.domain.WorkTime;
 import com.offnal.shifterz.work.domain.WorkTimeType;
 import com.offnal.shifterz.work.dto.WorkCalendarRequestDto;
+import com.offnal.shifterz.work.dto.WorkCalendarUnitDto;
 import com.offnal.shifterz.work.dto.WorkDayResponseDto;
 import com.offnal.shifterz.work.dto.WorkTimeDto;
 
@@ -16,7 +17,7 @@ import java.util.stream.Collectors;
 public class WorkCalendarConverter {
 
     // WorkCalendarRequestDto -> WorkCalendar
-    public static WorkCalendar toEntity(Long memberId, WorkCalendarRequestDto workCalendarRequestDto) {
+    public static WorkCalendar toEntity(Long memberId, WorkCalendarRequestDto workCalendarRequestDto, WorkCalendarUnitDto unitDto) {
 
         Map<String, WorkTime> workTimeMap = new HashMap<>();
         for (Map.Entry<String, WorkTimeDto> entry : workCalendarRequestDto.getWorkTimes().entrySet()) {
@@ -33,8 +34,8 @@ public class WorkCalendarConverter {
 
         return WorkCalendar.builder()
                 .calendarName(workCalendarRequestDto.getCalendarName())
-                .year(workCalendarRequestDto.getYear())
-                .month(workCalendarRequestDto.getMonth())
+                .year(unitDto.getYear())
+                .month(unitDto.getMonth())
                 .memberId(memberId)
                 .workGroup(workCalendarRequestDto.getWorkGroup())
                 .workTimes(workTimeMap)
@@ -42,8 +43,8 @@ public class WorkCalendarConverter {
     }
 
     // WorkCalendarRequestDto -> List<WorkInstance>
-    public static List<WorkInstance> toWorkInstances(WorkCalendarRequestDto workCalendarRequestDto, WorkCalendar calendar) {
-        return workCalendarRequestDto.getShifts().entrySet().stream()
+    public static List<WorkInstance> toWorkInstances(WorkCalendarUnitDto unitDto, WorkCalendar calendar) {
+        return unitDto.getShifts().entrySet().stream()
                 .map(entry -> WorkInstance.builder()
                         .workDay(entry.getKey())
                         .workTimeType(WorkTimeType.fromSymbol(entry.getValue()))

--- a/src/main/java/com/offnal/shifterz/work/domain/WorkCalendar.java
+++ b/src/main/java/com/offnal/shifterz/work/domain/WorkCalendar.java
@@ -14,7 +14,7 @@ import java.util.Map;
 @NoArgsConstructor
 @Getter
 @Builder
-@Table(name = "work_schedules")
+@Table(name = "work_calendar")
 public class WorkCalendar {
 
     @Id

--- a/src/main/java/com/offnal/shifterz/work/dto/WorkCalendarRequestDto.java
+++ b/src/main/java/com/offnal/shifterz/work/dto/WorkCalendarRequestDto.java
@@ -5,34 +5,21 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.Map;
+import java.util.List;
 
 @Getter
-@Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class WorkCalendarRequestDto {
+
     @NotEmpty(message = "근무표 이름은 필수입니다.")
     @NotNull
     @Schema(description = "근무표 이름")
     private String calendarName;
-
-    @NotEmpty(message = "연도는 필수입니다.")
-    @NotNull
-    @Pattern(regexp = "\\d{4}", message = "연도 형식이 올바르지 않습니다.")
-    @Schema(description = "연도")
-    private String year;
-
-    @NotEmpty(message = "월은 필수입니다.")
-    @NotNull
-    @Pattern(regexp = "^(0?[1-9]|1[0-2])$", message = "월 형식이 올바르지 않습니다.")
-    @Schema(description = "월")
-    private String month;
 
     @NotEmpty(message = "근무조는 필수입니다.")
     @NotNull
@@ -46,8 +33,7 @@ public class WorkCalendarRequestDto {
     private Map<String, WorkTimeDto> workTimes;
 
     @Valid
-    @NotEmpty(message = "근무일 정보는 필수입니다.")
-    @NotNull
-    @Schema(description = "근무표(날짜별 근무타입)")
-    private Map<String, String> shifts;
+    @NotEmpty(message = "캘린더 목록은 필수입니다.")
+    @Schema(description = "연도, 월, 날짜별 근무타입을 담은 캘린더 목록")
+    private List<WorkCalendarUnitDto> calendars;
 }

--- a/src/main/java/com/offnal/shifterz/work/dto/WorkCalendarRequestDto.java
+++ b/src/main/java/com/offnal/shifterz/work/dto/WorkCalendarRequestDto.java
@@ -4,11 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @Builder

--- a/src/main/java/com/offnal/shifterz/work/dto/WorkCalendarUnitDto.java
+++ b/src/main/java/com/offnal/shifterz/work/dto/WorkCalendarUnitDto.java
@@ -1,0 +1,35 @@
+package com.offnal.shifterz.work.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class WorkCalendarUnitDto {
+
+    @NotEmpty(message = "연도는 필수입니다.")
+    @NotNull
+    @Pattern(regexp = "\\d{4}", message = "연도 형식이 올바르지 않습니다.")
+    @Schema(description = "연도")
+    private String year;
+
+    @NotEmpty(message = "월은 필수입니다.")
+    @NotNull
+    @Pattern(regexp = "^(0?[1-9]|1[0-2])$", message = "월 형식이 올바르지 않습니다.")
+    @Schema(description = "월")
+    private String month;
+
+    @Valid
+    @NotEmpty(message = "근무일 정보는 필수입니다.")
+    @NotNull
+    @Schema(description = "근무표(날짜별 근무타입)")
+    private Map<String, String> shifts;
+}

--- a/src/main/java/com/offnal/shifterz/work/dto/WorkCalendarUnitDto.java
+++ b/src/main/java/com/offnal/shifterz/work/dto/WorkCalendarUnitDto.java
@@ -7,7 +7,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.util.Map;
 

--- a/src/main/java/com/offnal/shifterz/work/repository/WorkCalendarRepository.java
+++ b/src/main/java/com/offnal/shifterz/work/repository/WorkCalendarRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WorkCalendarRepository extends JpaRepository<WorkCalendar, Long> {
-
+    boolean existsByMemberIdAndYearAndMonth(Long memberId, String year, String month);
 }

--- a/src/main/java/com/offnal/shifterz/work/service/WorkCalendarService.java
+++ b/src/main/java/com/offnal/shifterz/work/service/WorkCalendarService.java
@@ -5,6 +5,7 @@ import com.offnal.shifterz.work.converter.WorkCalendarConverter;
 import com.offnal.shifterz.work.domain.WorkCalendar;
 import com.offnal.shifterz.work.domain.WorkInstance;
 import com.offnal.shifterz.work.dto.WorkCalendarRequestDto;
+import com.offnal.shifterz.work.dto.WorkCalendarUnitDto;
 import com.offnal.shifterz.work.dto.WorkDayResponseDto;
 import com.offnal.shifterz.work.repository.WorkCalendarRepository;
 import com.offnal.shifterz.work.repository.WorkInstanceRepository;
@@ -26,21 +27,24 @@ public class WorkCalendarService {
 
         Long memberId = AuthService.getCurrentUserId();
 
-        WorkCalendar calendar = WorkCalendarConverter.toEntity(memberId, workCalendarRequestDto);
-        WorkCalendar savedCalendar = workCalendarRepository.save(calendar);
+        for (WorkCalendarUnitDto unitDto : workCalendarRequestDto.getCalendars()) {
+            WorkCalendar calendar = WorkCalendarConverter.toEntity(memberId, workCalendarRequestDto, unitDto);
+            WorkCalendar savedCalendar = workCalendarRepository.save(calendar);
 
-        List<WorkInstance> instances = WorkCalendarConverter.toWorkInstances(workCalendarRequestDto, savedCalendar);
-        workInstanceRepository.saveAll(instances);
+            List<WorkInstance> instances = WorkCalendarConverter.toWorkInstances(unitDto, savedCalendar);
+            workInstanceRepository.saveAll(instances);
+        }
+
     }
-
 
     public List<WorkDayResponseDto> getWorkDaysByYearAndMonth(String year, String month) {
 
         Long memberId = AuthService.getCurrentUserId();
 
         List<WorkInstance> instances =
-                workInstanceRepository.findByWorkCalendar_MemberIdAndWorkCalendar_YearAndWorkCalendar_Month(memberId,year, month);
+                workInstanceRepository.findByWorkCalendar_MemberIdAndWorkCalendar_YearAndWorkCalendar_Month(memberId, year, month);
 
         return WorkCalendarConverter.toDayResponseDtoList(instances);
     }
+
 }

--- a/src/main/java/com/offnal/shifterz/work/service/WorkCalendarService.java
+++ b/src/main/java/com/offnal/shifterz/work/service/WorkCalendarService.java
@@ -1,6 +1,8 @@
 package com.offnal.shifterz.work.service;
 
 import com.offnal.shifterz.global.common.AuthService;
+import com.offnal.shifterz.global.exception.CustomException;
+import com.offnal.shifterz.global.exception.ErrorCode;
 import com.offnal.shifterz.work.converter.WorkCalendarConverter;
 import com.offnal.shifterz.work.domain.WorkCalendar;
 import com.offnal.shifterz.work.domain.WorkInstance;
@@ -28,6 +30,14 @@ public class WorkCalendarService {
         Long memberId = AuthService.getCurrentUserId();
 
         for (WorkCalendarUnitDto unitDto : workCalendarRequestDto.getCalendars()) {
+            // 중복 년도,달의 캘린더 체크 (memberId, year, month 중복 체크)
+            boolean exists = workCalendarRepository.existsByMemberIdAndYearAndMonth(
+                    memberId, unitDto.getYear(), unitDto.getMonth());
+
+            if (exists) {
+                throw new CustomException(ErrorCode.CALENDAR_DUPLICATION);
+            }
+
             WorkCalendar calendar = WorkCalendarConverter.toEntity(memberId, workCalendarRequestDto, unitDto);
             WorkCalendar savedCalendar = workCalendarRepository.save(calendar);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 🔀 변경 내용
- 캘린더 생성 시 여러 달의 근무표를 등록할 수 있도록 수정하였습니다.
     - 캘린더 이름, 근무조, 근무 시간은 공통사항이므로 년도, 월, 근무 일정만 배열로 받도록 수정하였습니다.
- 이미 캘린더가 생성된 달은 새로운 캘린더를 생성할 수 없도록 수정하였습니다.
- 스웨거의 `/callback` GET 요청을 숨김 처리 하였습니다. 

```json
{
  "calendarName": "병원 근무표",
  "workGroup": "1조",
  "workTimes": {
    "D": {
      "startTime": "08:00",
      "endTime": "16:00"
    },
    "E": {
      "startTime": "16:00",
      "endTime": "00:00"
    },
    "N": {
      "startTime": "00:00",
      "endTime": "08:00"
    }
  },
  "calendars": [
    {
      "year": "2025",
      "month": "7",
      "shifts": {
        "1": "E",
        "2": "E",
        "3": "N",
        "4": "-"
      }
    },
    {
      "year": "2025",
      "month": "8",
      "shifts": {
        "1": "E",
        "2": "E",
        "3": "N",
        "4": "-"
      }
    }
  ]
}
```


## ✅ 작업 항목
- [x] 여러 달의 근무표를 배열로 받도록 수정
- [x] 중복되는 달 체크
- [x] 에러 메시지 설정
- [x] 스웨거 카카오 로그인 콜백 처리 숨김
- [x] 테스트 완료 여부

## 📸 스크린샷 (선택)
<img width="737" height="199" alt="스크린샷 2025-07-13 021429" src="https://github.com/user-attachments/assets/df001004-6d5e-4ee7-8efb-107779b81fa6" />
중복되는 달의 캘린더 생성을 시도할 경우 아래와 같은 에러메시지가 뜹니다. 
<img width="1818" height="573" alt="image" src="https://github.com/user-attachments/assets/b6dd5da3-e6be-482c-9f6c-3592ca27cc08" />

## 📎 참고 이슈
#16