### PR TITLE
[deploy][yunnij] - eclipse-temurin:17-jre-alpine으로 Dockerfile 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM openjdk:17
-ARG JAR_FILE=*.jar
+FROM eclipse-temurin:17-jre-alpine
 
 COPY build/libs/shifterz-0.0.1-SNAPSHOT.jar app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
## 🔀 변경 내용
`openjdk` 이미지 deprecated에 따른 `eclipse-temurin`으로 이미지 변경

## ✅ 작업 항목
- openjdk 대신 eclipse-temurin 으로 수정

## 📸 스크린샷 (선택)

## 📎 참고 이슈
관련 이슈 번호#123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 유지보수
* 컨테이너 이미지를 경량화하여 배포 효율을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->