### PR TITLE
[feat][jjaeroong]: 근무 일정 조회/오늘의 루틴 조회 controller swagger api 예시 응답 추가

### DIFF
--- a/src/main/java/com/offnal/shifterz/global/response/SuccessApiResponses.java
+++ b/src/main/java/com/offnal/shifterz/global/response/SuccessApiResponses.java
@@ -793,4 +793,76 @@ public @interface SuccessApiResponses {
     @Retention(RetentionPolicy.RUNTIME)
     public @interface TokenReissue {}
 
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "근무 일정 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "근무 일정 조회 성공 예시",
+                                            value = """
+                                            {
+                                              "code": "HOME001",
+                                              "message": "근무 일정을 성공적으로 조회했습니다.",
+                                              "data": {
+                                                "yesterdayType": "DAY",
+                                                "todayType": "OFF",
+                                                "tomorrowType": "DAY"
+                                              }
+                                            }
+                                            """
+                                    )
+                            }
+                    )
+            )
+    })
+    public @interface HomeSchedule {}
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "오늘의 루틴 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "오늘의 루틴 조회 성공 예시",
+                                            value = """
+                                            {
+                                              "code": "HOME002",
+                                              "message": "루틴을 성공적으로 조회했습니다.",
+                                              "data": {
+                                                "meals": [
+                                                  {
+                                                    "label": "점심",
+                                                    "time": "13:30",
+                                                    "description": "기상 후 체력 회복",
+                                                    "items": ["김밥", "칼국수"]
+                                                  }
+                                                ],
+                                                "health": {
+                                                  "fastingComment": "생체 리듬 유지에 집중",
+                                                  "fastingSchedule": "저녁 식사 후 공복 유지",
+                                                  "sleepGuide": ["08:00 ~ 13:00 수면"],
+                                                  "sleepSchedule": "수면 22:00 ~ 05:00"
+                                                }
+                                              }
+                                            }
+                                            """
+                                    )
+                            }
+                    )
+            )
+    })
+    public @interface HomeRoutine {}
+
+
 }

--- a/src/main/java/com/offnal/shifterz/home/controller/HomeController.java
+++ b/src/main/java/com/offnal/shifterz/home/controller/HomeController.java
@@ -1,6 +1,7 @@
 package com.offnal.shifterz.home.controller;
 
 import com.offnal.shifterz.global.exception.ErrorApiResponses;
+import com.offnal.shifterz.global.response.SuccessApiResponses;
 import com.offnal.shifterz.global.response.SuccessCode;
 import com.offnal.shifterz.global.response.SuccessResponse;
 import com.offnal.shifterz.home.dto.DailyRoutineResDto;
@@ -59,6 +60,7 @@ public class HomeController {
                     )
             )
     })
+    @SuccessApiResponses.HomeSchedule
     @ErrorApiResponses.Common
     @GetMapping("/schedule")
     public SuccessResponse<WorkScheduleResponseDto> getWorkSchedule() {
@@ -106,6 +108,7 @@ public class HomeController {
                     )
             )
     })
+    @SuccessApiResponses.HomeRoutine
     @ErrorApiResponses.Common
     @GetMapping("/routine")
     public SuccessResponse<DailyRoutineResDto> getDailyRoutine() {
@@ -153,6 +156,7 @@ public class HomeController {
                     )
             )
     })
+    @SuccessApiResponses.HomeRoutine
     @ErrorApiResponses.Common
     @GetMapping("/routine/{date}")
     public SuccessResponse<DailyRoutineResDto> getDailyRoutineByDate(


### PR DESCRIPTION
## 🔀 변경 내용
- 근무 일정 조회/오늘의 루틴 조회 controller swagger api 응답예시 추가
- 
## ✅ 작업 항목
- [ ] 작업 1
- [ ] 작업 2
- [ ] 테스트 완료 여부

## 📸 스크린샷 (선택)

## 📎 참고 이슈
관련 이슈 번호#63