### PR TITLE
[Chore] - presigned url 발급 제한 삭제

### DIFF
--- a/src/main/java/com/offnal/shifterz/global/util/S3Service.java
+++ b/src/main/java/com/offnal/shifterz/global/util/S3Service.java
@@ -35,6 +35,7 @@ public class S3Service {
     private final S3Presigner s3Presigner;
     private final S3Client s3Client;
     private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
@@ -55,9 +56,16 @@ public class S3Service {
 
         extension = normalizeExtension(extension);
 
-        String key = FOLDER + "/member-" + memberId + "-profile-" + UUID.randomUUID() + "." + extension;
-
         String contentType = getContentTypeFromExtension(extension);
+
+        String key;
+        if (member.getProfileImageKey() != null && !member.getProfileImageKey().isEmpty()) {
+            key = member.getProfileImageKey();
+        } else{
+            key = FOLDER + "/member-" + memberId + "-profile-" + UUID.randomUUID() + "." + extension;
+            memberService.updateProfileImage(key);
+        }
+
 
         PutObjectRequest objectRequest = PutObjectRequest.builder()
                 .bucket(bucket)


### PR DESCRIPTION
## 🔀 변경 내용
### 기존 로직
회원 정보에 key가 등록되어 있다면 presigned url 발급 불가
### 변경 로직
이미지 변경을 위해 위 발급 제한 삭제. key가 있어도 presigned url 발급 가능.

## ✅ 작업 항목
- [x] presigned url 발급 제한 삭제

## 📸 스크린샷 (선택)

## 📎 참고 이슈
관련 이슈 번호#123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 프로필 이미지 중복 생성 오류 방지

* **개선 사항**
  * 프로필 이미지 처리 로직 최적화 및 일관성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->