### PR TITLE
[fix][jjaeroong]: 조직 삭제 시, 팀 삭제 로직 추가

### DIFF
--- a/src/main/java/com/offnal/shifterz/memberOrganizationTeam/repository/MemberOrganizationTeamRepository.java
+++ b/src/main/java/com/offnal/shifterz/memberOrganizationTeam/repository/MemberOrganizationTeamRepository.java
@@ -26,5 +26,6 @@ public interface MemberOrganizationTeamRepository
             @Param("organizationName") String organizationName
     );
     void deleteAllByMemberId(Long memberId);
+    void deleteAllByOrganization(Organization organization);
 }
 

--- a/src/main/java/com/offnal/shifterz/organization/service/OrganizationService.java
+++ b/src/main/java/com/offnal/shifterz/organization/service/OrganizationService.java
@@ -4,6 +4,7 @@ import com.offnal.shifterz.global.common.AuthService;
 import com.offnal.shifterz.global.exception.CustomException;
 import com.offnal.shifterz.global.exception.ErrorReason;
 import com.offnal.shifterz.member.domain.Member;
+import com.offnal.shifterz.memberOrganizationTeam.repository.MemberOrganizationTeamRepository;
 import com.offnal.shifterz.memo.repository.MemoRepository;
 import com.offnal.shifterz.organization.converter.OrganizationConverter;
 import com.offnal.shifterz.organization.domain.Organization;
@@ -29,6 +30,7 @@ public class OrganizationService {
     private final OrganizationRepository organizationRepository;
     private final MemoRepository memoRepository;
     private final TodoRepository todoRepository;
+    private final MemberOrganizationTeamRepository memberOrganizationTeamRepository;
     private static final String ORG_CONSTRAINT_NAME = "uk_org_member_name_team";
 
 
@@ -167,7 +169,7 @@ public class OrganizationService {
 
         memoRepository.deleteAllByOrganization(org);
         todoRepository.deleteAllByOrganization(org);
-
+        memberOrganizationTeamRepository.deleteAllByOrganization(org);
         organizationRepository.delete(org);
     }
 


### PR DESCRIPTION
## 🔀 변경 내용
-  조직 삭제 시, 팀 삭제 로직 추가
## ✅ 작업 항목
- [ ] MemberOrganizationTeamRepositroy 
- [ ] Organizatino 팀 삭제 메서드
- [ ] 테스트 완료 여부

## 📸 스크린샷 (선택)
<img width="1082" height="728" alt="스크린샷 2025-11-21 144006" src="https://github.com/user-attachments/assets/81d93e06-cbc5-4cad-af5c-3fc07041a8d9" />
## 📎 참고 이슈
관련 이슈 번호#123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- 조직 삭제 시 관련된 회원 조직 팀 정보가 함께 올바르게 제거되도록 개선하여 데이터 일관성 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->