### PR TITLE
[fix][yunnij] - home 근무 일정 조회 및 루틴 조회 수정

### DIFF
--- a/src/main/java/com/offnal/shifterz/home/service/HomeService.java
+++ b/src/main/java/com/offnal/shifterz/home/service/HomeService.java
@@ -1,11 +1,16 @@
 package com.offnal.shifterz.home.service;
 
 import com.offnal.shifterz.global.common.AuthService;
+import com.offnal.shifterz.global.exception.CustomException;
 import com.offnal.shifterz.global.exception.ErrorReason;
+import com.offnal.shifterz.home.converter.HomeDetailConverter;
 import com.offnal.shifterz.home.converter.WorkScheduleContextConverter;
 import com.offnal.shifterz.home.dto.DailyRoutineResDto;
 import com.offnal.shifterz.home.dto.WorkScheduleContext;
 import com.offnal.shifterz.home.dto.WorkScheduleResponseDto;
+import com.offnal.shifterz.memberOrganizationTeam.domain.MemberOrganizationTeam;
+import com.offnal.shifterz.memberOrganizationTeam.repository.MemberOrganizationTeamRepository;
+import com.offnal.shifterz.organization.domain.Organization;
 import com.offnal.shifterz.work.converter.WorkCalendarConverter;
 import com.offnal.shifterz.work.domain.WorkInstance;
 import com.offnal.shifterz.work.domain.WorkTime;
@@ -30,39 +35,29 @@ public class HomeService {
     private final WorkCalendarRepository workCalendarRepository;
     private final WorkScheduleContextConverter contextConverter;
     private final WorkInstanceRepository workInstanceRepository;
+    private final MemberOrganizationTeamRepository memberOrganizationTeamRepository;
+    private final HomeDetailConverter homeDetailConverter;
 
     @Transactional(readOnly = true)
     public WorkScheduleResponseDto getWorkSchedule() {
         Long memberId = AuthService.getCurrentUserId();
         LocalDate today = LocalDate.now();
 
-        WorkTimeType yesterdayType = workScheduleService.findWorkType(today.minusDays(1), memberId);
-        WorkTimeType todayType = workScheduleService.findWorkType(today, memberId);
-        WorkTimeType tomorrowType = workScheduleService.findWorkType(today.plusDays(1), memberId);
+        MemberOrganizationTeam memberOrgTeam = memberOrganizationTeamRepository
+                .findByMemberId(memberId)
+                .orElseThrow(() -> new CustomException(HomeErrorCode.MY_TEAM_NOT_FOUND));
 
+        Organization org = getMyTeamOrganization(memberId);
 
-        WorkInstance todayInstance =
-                workInstanceRepository.findByWorkCalendarMemberIdAndWorkDate(memberId, today)
-                        .orElse(null);
+        WorkTimeType yesterdayType = findTypeForOrg(org, today.minusDays(1));
+        WorkTimeType todayType = findTypeForOrg(org, today);
+        WorkTimeType tomorrowType = findTypeForOrg(org, today.plusDays(1));
 
-        WorkTime workTime = null;
+        WorkTime workTime = getTodayWorkTime(org, today);
 
-        if (todayInstance != null) {
-            workTime = WorkCalendarConverter.resolveWorkTimeFor(todayInstance);
-        }
-
-        WorkScheduleContext context = contextConverter.toContext(
-                memberId,
-                today,
-                yesterdayType,
-                todayType,
-                tomorrowType,
-                workTime
+        DailyRoutineResDto routine = buildRoutineIfNeeded(
+                memberId, today, yesterdayType, todayType, tomorrowType, workTime
         );
-
-        if (context.getTodayType() != null) {
-            dailyRoutineService.buildRoutine(context);
-        }
 
         return WorkScheduleResponseDto.builder()
                 .yesterdayType(yesterdayType)
@@ -71,7 +66,40 @@ public class HomeService {
                 .build();
     }
 
+    private DailyRoutineResDto buildRoutineIfNeeded(
+            Long memberId, LocalDate today, WorkTimeType yesterdayType, WorkTimeType todayType, WorkTimeType tomorrowType, WorkTime workTime
+    ) {
+        WorkScheduleContext context = contextConverter.toContext(
+                memberId, today, yesterdayType, todayType, tomorrowType, workTime
+        );
 
+        if (context.getTodayType() == null) {
+            return null;
+        }
+
+        return dailyRoutineService.buildRoutine(context);
+    }
+
+    private WorkTime getTodayWorkTime(Organization org, LocalDate today) {
+        return workInstanceRepository
+                .findByWorkCalendarOrganizationAndWorkDate(org, today)
+                .map(WorkCalendarConverter::resolveWorkTimeFor)
+                .orElse(null);
+    }
+
+    private WorkTimeType findTypeForOrg(Organization org, LocalDate date) {
+        return workInstanceRepository
+                .findByWorkCalendarOrganizationAndWorkDate(org, date)
+                .map(WorkInstance::getWorkTimeType)
+                .orElse(null);
+    }
+
+    private Organization getMyTeamOrganization(Long memberId) {
+        return memberOrganizationTeamRepository
+                .findByMemberId(memberId)
+                .map(MemberOrganizationTeam::getOrganization)
+                .orElseThrow(() -> new CustomException(HomeErrorCode.MY_TEAM_NOT_FOUND));
+    }
 
 
     public DailyRoutineResDto getDailyRoutine() {
@@ -91,7 +119,8 @@ public class HomeService {
 
         //근무 관련
         WORK_INSTANCE_NOT_FOUND("HOME001", HttpStatus.NOT_FOUND, "해당 일자에 저장된 근무 정보가 없습니다."),
-        WORK_TIME_NOT_FOUND("HOME002",HttpStatus.NOT_FOUND, "오늘의 근무 시간 정보가 없습니다.");
+        WORK_TIME_NOT_FOUND("HOME002",HttpStatus.NOT_FOUND, "오늘의 근무 시간 정보가 없습니다."),
+        MY_TEAM_NOT_FOUND("HOME003", HttpStatus.NOT_FOUND, "해당하는 팀이 없습니다.");
 
         private final String code;
         private final HttpStatus status;

--- a/src/main/java/com/offnal/shifterz/home/service/WorkScheduleService.java
+++ b/src/main/java/com/offnal/shifterz/home/service/WorkScheduleService.java
@@ -3,6 +3,11 @@ package com.offnal.shifterz.home.service;
 import com.offnal.shifterz.global.exception.CustomException;
 import com.offnal.shifterz.home.dto.WorkScheduleContext;
 import com.offnal.shifterz.home.service.HomeService.HomeErrorCode;
+import com.offnal.shifterz.member.domain.Member;
+import com.offnal.shifterz.member.service.MemberService;
+import com.offnal.shifterz.memberOrganizationTeam.domain.MemberOrganizationTeam;
+import com.offnal.shifterz.memberOrganizationTeam.repository.MemberOrganizationTeamRepository;
+import com.offnal.shifterz.organization.domain.Organization;
 import com.offnal.shifterz.work.domain.WorkInstance;
 import com.offnal.shifterz.work.domain.WorkTime;
 import com.offnal.shifterz.work.domain.WorkTimeType;
@@ -17,26 +22,31 @@ import java.time.LocalDate;
 public class WorkScheduleService {
 
     private final WorkInstanceRepository workInstanceRepository;
+    private final MemberOrganizationTeamRepository memberOrganizationTeamRepository;
 
-    public WorkTimeType findWorkType(LocalDate date, Long memberId) {
+    public WorkTimeType findWorkType(LocalDate date, Long memberId, Organization organization) {
         return workInstanceRepository
-                .findByWorkDateAndMemberIdThroughWorkCalendar(date, memberId)
-                .map(WorkInstance::getWorkTimeType)
+                .findTypeByDateAndMemberAndOrganization(date, memberId, organization)
                 .orElse(null);
-
     }
 
     public WorkScheduleContext getWorkScheduleContext(Long memberId, LocalDate date) {
+        MemberOrganizationTeam mot = memberOrganizationTeamRepository
+                .findByMemberId(memberId)
+                .orElseThrow(() -> new CustomException(HomeErrorCode.MY_TEAM_NOT_FOUND));
+
+        Organization organization = mot.getOrganization();
+
         LocalDate yesterday = date.minusDays(1);
         LocalDate tomorrow = date.plusDays(1);
 
-        WorkTimeType yesterdayType = findWorkType(yesterday, memberId);
-        WorkTimeType todayType = findWorkType(date, memberId);
-        WorkTimeType tomorrowType = findWorkType(tomorrow, memberId);
+        WorkTimeType yesterdayType = findWorkType(yesterday, memberId, organization);
+        WorkTimeType todayType = findWorkType(date, memberId, organization);
+        WorkTimeType tomorrowType = findWorkType(tomorrow, memberId, organization);
 
         // 오늘 근무 정보 조회
         WorkInstance todayWork = workInstanceRepository
-                .findByWorkDateAndMemberIdThroughWorkCalendar(date, memberId)
+                .findByWorkDateAndMemberIdAndOrganization(date, memberId, organization)
                 .orElseThrow(() -> new CustomException(HomeErrorCode.WORK_INSTANCE_NOT_FOUND));
 
         WorkTime workTime = null;

--- a/src/main/java/com/offnal/shifterz/memberOrganizationTeam/repository/MemberOrganizationTeamRepository.java
+++ b/src/main/java/com/offnal/shifterz/memberOrganizationTeam/repository/MemberOrganizationTeamRepository.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 @Repository
 public interface MemberOrganizationTeamRepository
         extends JpaRepository<MemberOrganizationTeam, Long> {
+    Optional<MemberOrganizationTeam> findByMemberId(Long memberId);
 
     Optional<MemberOrganizationTeam> findByMemberAndOrganization(Member member, Organization organization);
     @Query("""
@@ -25,6 +26,9 @@ public interface MemberOrganizationTeamRepository
             @Param("memberId") Long memberId,
             @Param("organizationName") String organizationName
     );
+
+    Optional<MemberOrganizationTeam> findByMemberIdAndTeam(Long memberId, String team);
+
     void deleteAllByMemberId(Long memberId);
     void deleteAllByOrganization(Organization organization);
 }

--- a/src/main/java/com/offnal/shifterz/work/repository/WorkInstanceRepository.java
+++ b/src/main/java/com/offnal/shifterz/work/repository/WorkInstanceRepository.java
@@ -65,8 +65,31 @@ public interface WorkInstanceRepository extends JpaRepository<WorkInstance, Long
             @Param("endDate") LocalDate endDate
     );
 
-    boolean existsByWorkCalendarMemberIdAndWorkDateAndWorkTimeType(
-            Long memberId, LocalDate date, WorkTimeType type);
+    Optional<WorkInstance> findByWorkCalendarOrganizationAndWorkDate(Organization organization, LocalDate date);
 
+
+    @Query("""
+    SELECT wi.workTimeType
+    FROM WorkInstance wi
+    WHERE wi.workDate = :date
+      AND wi.workCalendar.memberId = :memberId
+      AND wi.workCalendar.organization = :organization
+""")
+    Optional<WorkTimeType> findTypeByDateAndMemberAndOrganization(
+            @Param("date") LocalDate date,
+            @Param("memberId") Long memberId,
+            @Param("organization") Organization organization
+    );
+
+    @Query("""
+    SELECT wi FROM WorkInstance wi
+    WHERE wi.workDate = :date
+      AND wi.workCalendar.memberId= :memberId
+      AND wi.workCalendar.organization = :organization
+""")
+    Optional<WorkInstance> findByWorkDateAndMemberIdAndOrganization(
+            @Param("date") LocalDate date,
+            @Param("memberId") Long memberId,
+            @Param("organization") Organization organization);
 
 }


### PR DESCRIPTION
## 🔀 변경 내용
- home api에서 근무 일정 및 루틴 조회 로직을 수정하였습니다.

## ✅ 작업 항목
- [x] 서버 시간 UTC -> KST
- [x] 근무 일정 조회 시 myTeam에 해당하는 캘린더 일정 조회로 수정
- [x] 테스트 완료 여부

## 📸 스크린샷 (선택)
<img width="1507" height="1039" alt="스크린샷 2025-11-22 183046" src="https://github.com/user-attachments/assets/05650d11-174c-4c64-a8ef-9af502fbc65f" />
<img width="1491" height="568" alt="스크린샷 2025-11-22 183034" src="https://github.com/user-attachments/assets/323f41b2-4691-4706-928c-624822183899" />
<img width="1517" height="883" alt="스크린샷 2025-11-22 183026" src="https://github.com/user-attachments/assets/710537c9-0a0a-418a-a7e4-b968bfa2f2d0" />


## 📎 참고 이슈
관련 이슈 번호#123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 조직 범위의 작업 시간 관리 기능 추가로 사용자가 소속된 조직의 일정을 정확히 조회할 수 있습니다.

* **Bug Fixes**
  * 팀 및 조직 조회 실패 시 명확한 오류 메시지 제공으로 시스템 안정성을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->