### PR TITLE
[feat][jjaeroong]: 애플 로그인 수정 및 회원탈퇴 기능 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      # Gradle 캐시 최적화
       - name: Cache Gradle
         uses: actions/cache@v3
         with:
@@ -37,7 +36,7 @@ jobs:
       - name: Build Jar
         run: |
           chmod +x ./gradlew
-          ./gradlew clean bootJar
+          ./gradlew clean bootJar --no-daemon
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -50,7 +49,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
+          
       - name: Build & Push Docker Image
         uses: docker/build-push-action@v4
         with:
@@ -62,6 +61,7 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/offnal-be:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
 
   deploy:
     if: github.event_name == 'push' || github.event.pull_request.merged == true
@@ -92,10 +92,13 @@ jobs:
             set -e
             cd /home/ubuntu/Offnal-BE
 
+            # Docker Hub login
             echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
-            
-            NEW_IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/offnal-be:${IMAGE_TAG}"
+
+            NEW_IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/offnal-be:latest"
             echo "===== Deploying $NEW_IMAGE ====="
+
+            docker pull $NEW_IMAGE
 
             if grep -q "server spring_blue:8080" nginx/conf.d/default.conf; then
               CURRENT_COLOR="blue"
@@ -107,13 +110,11 @@ jobs:
               CURRENT_COLOR="green"
               NEW_COLOR="blue"
               NEW_SERVICE="spring_blue"
-              NEW_PORT=8080
+              NEW_PORT=8080"
               CURRENT_SERVICE="spring_green"
             fi
-
+ 
             echo "CURRENT=$CURRENT_COLOR, NEW=$NEW_COLOR"
-
-            docker pull $NEW_IMAGE
 
             sudo docker-compose stop $NEW_SERVICE || true
             sudo docker-compose rm -f $NEW_SERVICE || true
@@ -155,6 +156,10 @@ jobs:
               echo "Nginx Failed. Rolling back..."
               exit 1
             fi
+
+            sleep 5
+            sudo docker-compose stop $CURRENT_SERVICE
+            sudo docker-compose rm -f $CURRENT_SERVICE
 
             sleep 5
             sudo docker-compose stop $CURRENT_SERVICE

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,7 @@ jobs:
 
             echo "Health Check..."
             HEALTH=false
-            for i in {1..20}; do
+            for i in {1..40}; do
               sleep 3
               if curl -f http://localhost:${NEW_PORT}/actuator/health > /dev/null 2>&1; then
                 echo "Health OK"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,7 +110,7 @@ jobs:
               CURRENT_COLOR="green"
               NEW_COLOR="blue"
               NEW_SERVICE="spring_blue"
-              NEW_PORT=8080"
+              NEW_PORT=8080
               CURRENT_SERVICE="spring_green"
             fi
  

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
 
 	// aws s3
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.0'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   spring_blue:
     container_name: spring_blue
-    image: ${DOCKERHUB_USERNAME}/offnal-be:${IMAGE_TAG:-latest}
+    image: ${DOCKERHUB_USERNAME}/offnal-be:latest
     ports:
       - "8080:8080"
     restart: always
@@ -21,7 +21,7 @@ services:
 
   spring_green:
     container_name: spring_green
-    image: ${DOCKERHUB_USERNAME}/offnal-be:${IMAGE_TAG:-latest}
+    image: ${DOCKERHUB_USERNAME}/offnal-be:latest
     ports:
       - "8081:8080"
     restart: always

--- a/src/main/java/com/offnal/shifterz/global/config/SecurityConfig.java
+++ b/src/main/java/com/offnal/shifterz/global/config/SecurityConfig.java
@@ -40,7 +40,11 @@ public class SecurityConfig {
                                         "/swagger-ui.html",
                                         "/swagger-ui/**",
                                         "/v3/api-docs/**",
-                                        "/error").permitAll()
+                                        "/error",
+                                        "/actuator/health",     // ← 추가!
+                                        "/actuator/**"
+
+                                ).permitAll()
                                 .anyRequest().authenticated()
                 )
                 .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/offnal/shifterz/member/domain/Member.java
+++ b/src/main/java/com/offnal/shifterz/member/domain/Member.java
@@ -37,11 +37,14 @@ public class Member extends BaseTimeEntity {
 
     private String profileImageKey;
 
+    private String appleRefreshToken;
+
     public void updateMemberInfo(String memberName, String profileImageKey) {
         this.memberName = memberName;
         this.profileImageKey = profileImageKey;
 
     }
-
-
+    public void updateAppleRefreshToken(String token) {
+        this.appleRefreshToken = token;
+    }
 }

--- a/src/main/java/com/offnal/shifterz/oauth/LoginService.java
+++ b/src/main/java/com/offnal/shifterz/oauth/LoginService.java
@@ -44,14 +44,11 @@ public class LoginService {
 
     public AuthResponseDto loginWithAppleNative(AppleLoginRequest request) {
 
-        // 1) identityToken 검증 → Apple User Info 획득
         AppleUserInfoResponseDto userInfo = appleService.getUserInfoFromIdentityToken(request);
 
-        // 2) authorizationCode → Apple refresh_token 발급
         AppleAuthTokenResponse appleToken =
                 appleService.exchangeAuthorizationCode(request.getAuthorizationCode());
-        log.info("🔍 [Login Stage] refresh_token = {}", appleToken.getRefreshToken());
-        // 3) handleAppleLogin 에 refresh_token 도 넘김
+
         return handleAppleLogin(userInfo, request, appleToken);
     }
 

--- a/src/main/java/com/offnal/shifterz/oauth/apple/AppleAuthTokenResponse.java
+++ b/src/main/java/com/offnal/shifterz/oauth/apple/AppleAuthTokenResponse.java
@@ -1,0 +1,23 @@
+package com.offnal.shifterz.oauth.apple;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class AppleAuthTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("id_token")
+    private String idToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+}

--- a/src/main/java/com/offnal/shifterz/oauth/apple/AppleLoginRequest.java
+++ b/src/main/java/com/offnal/shifterz/oauth/apple/AppleLoginRequest.java
@@ -13,6 +13,9 @@ public class AppleLoginRequest {
     @Schema(description = "iOS 네이티브 로그인에서 받은 identityToken(JWT)", required = true)
     private String identityToken;
 
+    @Schema(description = "Authorization Code", required = true)
+    private String authorizationCode;
+
     @Schema(description = "Apple 고유 사용자 ID (user identifier)")
     private String user;
 

--- a/src/main/java/com/offnal/shifterz/oauth/apple/AppleService.java
+++ b/src/main/java/com/offnal/shifterz/oauth/apple/AppleService.java
@@ -66,8 +66,6 @@ public class AppleService implements AppleSocialService {
     private long lastFetchTime = 0L;
 
 
-    /* --------------------- 1) identityToken 검증 --------------------- */
-
     @Override
     public AppleUserInfoResponseDto getUserInfoFromIdentityToken(AppleLoginRequest request) {
 
@@ -102,8 +100,6 @@ public class AppleService implements AppleSocialService {
         }
     }
 
-
-    /* --------------------- JWKS 공개키 로딩 --------------------- */
 
     private PublicKey getApplePublicKey(String kid) {
         try {
@@ -149,7 +145,6 @@ public class AppleService implements AppleSocialService {
     }
 
 
-    /* --------------------- 2) AuthorizationCode → AppleToken 교환 --------------------- */
 
     public AppleAuthTokenResponse exchangeAuthorizationCode(String authorizationCode) {
 
@@ -172,7 +167,6 @@ public class AppleService implements AppleSocialService {
                         String.class
                 );
 
-        log.info("🍎 [Apple Token RAW] {}", rawResponse.getBody());
 
         if (!rawResponse.getStatusCode().is2xxSuccessful()) {
             throw new CustomException(AppleErrorCode.APPLE_TOKEN_EXCHANGE_FAIL);
@@ -185,7 +179,6 @@ public class AppleService implements AppleSocialService {
                     AppleAuthTokenResponse.class
             );
 
-            log.info("🍏 [Apple refresh_token] {}", token.getRefreshToken());
             return token;
 
         } catch (Exception e) {
@@ -197,12 +190,10 @@ public class AppleService implements AppleSocialService {
 
 
     private String createClientSecret() {
-        log.info("=== [Apple] createClientSecret() ENTER ===");
 
         try {
             String keyPath = appleProperties.privateKeyPath();
 
-            log.info("[Apple] privateKeyPath property = {}", keyPath);
 
             String privateKeyPem;
 
@@ -210,13 +201,10 @@ public class AppleService implements AppleSocialService {
 
                 Resource resource = resourceLoader.getResource(keyPath);
                 privateKeyPem = new String(resource.getInputStream().readAllBytes());
-                log.info("[Apple] Loaded private key from classpath");
             } else {
 
                 Path path = Paths.get(keyPath);
-                log.info("[Apple] Attempting to read file from: {}", path.toAbsolutePath());
                 privateKeyPem = Files.readString(path);
-                log.info("[Apple] Loaded private key from filesystem");
             }
 
             privateKeyPem = privateKeyPem
@@ -247,12 +235,10 @@ public class AppleService implements AppleSocialService {
         }
     }
 
-    /* --------------------- 4) Revoke --------------------- */
 
     public void revoke(Member member) {
 
         if (member.getAppleRefreshToken() == null) {
-            log.warn("[Apple Revoke] refresh_token 없음, skip");
             return;
         }
 

--- a/src/main/java/com/offnal/shifterz/oauth/apple/AppleUserInfoResponseDto.java
+++ b/src/main/java/com/offnal/shifterz/oauth/apple/AppleUserInfoResponseDto.java
@@ -20,7 +20,6 @@ public class AppleUserInfoResponseDto {
     @JsonProperty("is_private_email")
     private Boolean isPrivateEmail;
 
-    // 생성자 추가 (토큰 파싱 후 직접 생성용)
     public AppleUserInfoResponseDto(String sub, String email) {
         this.sub = sub;
         this.email = email;


### PR DESCRIPTION
## 🔀 변경 내용
- 애플 로그인 수정 및 회원탈퇴 기능 구현

## ✅ 작업 항목
- [ ] 애플로그인 -> client secrest 발급
- [ ] 회원탈퇴 시 애플 api 호출
- [ ] 테스트 완료 여부

## 📸 스크린샷 (선택)
<img width="483" height="384" alt="image" src="https://github.com/user-attachments/assets/9b078c87-0c26-4ea3-a36f-c95161f37b4a" />
<img width="570" height="528" alt="image" src="https://github.com/user-attachments/assets/e80a132a-c105-4abf-91b5-9d7c31a7984c" />

## 📎 참고 이슈
관련 이슈 번호#126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Apple 계정 토큰 관리 및 갱신 기능 추가
  * Apple 계정 연동 해제 시 토큰 무효화 기능 추가

* **Improvements**
  * 서비스 배포 프로세스의 안정성 및 신뢰성 강화
  * 헬스 체크 대기 시간 연장으로 서비스 준비 상태 확인 개선
  * Docker 이미지 관리 및 배포 워크플로우 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->