### PR TITLE
[deploy][yunnij] prod 환경에서 swagger 접근 금지

### DIFF
--- a/src/main/java/com/offnal/shifterz/global/config/SwaggerConfig.java
+++ b/src/main/java/com/offnal/shifterz/global/config/SwaggerConfig.java
@@ -10,7 +10,9 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Profile;
 
+@Profile("!prod")
 @Configuration
 public class SwaggerConfig {
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -39,3 +39,8 @@ apple:
   key-id: ${APPLE_KEY_ID}
   private-key-path: ${APPLE_PRIVATE_KEY_PATH}
   redirect-uri: ${APPLE_REDIRECT_URI}
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false


### PR DESCRIPTION
## 🔀 변경 내용
- 상용 서버에서 swagger에 접근할 수 없도록 설정하였습니다

## ✅ 작업 항목
- [x] `SwaggerConfig`에 `@Profile("!prod")` 추가
- [x] application-prod.yml에 swagger 설정 추가

## 📸 스크린샷 (선택)

## 📎 참고 이슈
관련 이슈 번호#123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **설정**
  * 프로덕션 환경에서 API 문서 및 Swagger UI 비활성화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->