### PR TITLE
[OFFNAL-25 / Feat][yunnij]: Health Check API 추가

### DIFF
--- a/src/main/java/com/offnal/shifterz/global/config/SecurityConfig.java
+++ b/src/main/java/com/offnal/shifterz/global/config/SecurityConfig.java
@@ -38,6 +38,8 @@ public class SecurityConfig {
 		http.cors().and() //CORS 활성화 추가
 			.authorizeHttpRequests(authorizeRequests ->
 				authorizeRequests.requestMatchers(
+						"/health/**",
+						"/actuator/health/**",
 						"/login/**",
 						"/login/page/**",
 						"/tokens/reissue",

--- a/src/main/java/com/offnal/shifterz/global/health/HealthController.java
+++ b/src/main/java/com/offnal/shifterz/global/health/HealthController.java
@@ -1,0 +1,100 @@
+package com.offnal.shifterz.global.health;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.HealthComponent;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Health", description = "헬스체크 API")
+@RestController
+@RequiredArgsConstructor
+public class HealthController {
+    private final HealthEndpoint healthEndpoint;
+
+    @Operation(
+            summary = "Liveness Check",
+            description = """
+                    애플리케이션 프로세스가 살아있는지 확인합니다.
+                    
+                    - status: 전체 상태 (UP/DOWN)
+                    - components.ping: 애플리케이션 자체 상태
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 응답",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(
+                            name = "Liveness Example",
+                            value = """
+                                    {
+                                      "status": "UP",
+                                      "components": {
+                                        "ping": {
+                                          "status": "UP"
+                                        }
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    @GetMapping("/health/liveness")
+    public ResponseEntity<HealthComponent> liveness() {
+        return ResponseEntity.ok(healthEndpoint.healthForPath("liveness"));
+    }
+
+    @Operation(
+            summary = "Readiness Check",
+            description = """
+                    트래픽을 받을 준비가 되었는지 확인합니다.
+                    
+                    - status: 전체 상태 (UP/DOWN)
+                    - components.db: 데이터베이스 연결 상태
+                    - components.redis: Redis 연결 상태
+                    - details: 각 컴포넌트의 추가 정보
+                    """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "정상 응답",
+            content = @Content(
+                    mediaType = "application/json",
+                    examples = @ExampleObject(
+                            name = "Readiness Example",
+                            value = """
+                                    {
+                                      "status": "UP",
+                                      "components": {
+                                        "db": {
+                                          "status": "UP",
+                                          "details": {
+                                            "database": "MySQL",
+                                            "validationQuery": "isValid()"
+                                          }
+                                        },
+                                        "redis": {
+                                          "status": "UP",
+                                          "details": {
+                                            "version": "8.2.1"
+                                          }
+                                        }
+                                      }
+                                    }
+                                    """
+                    )
+            )
+    )
+    @GetMapping("/health/readiness")
+    public ResponseEntity<HealthComponent> readiness() {
+        return ResponseEntity.ok(healthEndpoint.healthForPath("readiness"));
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -43,3 +43,9 @@ apple:
 encrypt:
   aes:
     key: ${AES_ENCRYPTION_KEY}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -43,8 +43,6 @@ apple:
 encrypt:
   aes:
     key: ${AES_ENCRYPTION_KEY}
-  migration:
-    enabled: true
 
 management:
   endpoints:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -46,3 +46,9 @@ apple:
 encrypt:
   aes:
     key: ${AES_ENCRYPTION_KEY}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -46,8 +46,6 @@ apple:
 encrypt:
   aes:
     key: ${AES_ENCRYPTION_KEY}
-  migration:
-    enabled: true
 
 management:
   endpoints:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -48,3 +48,9 @@ springdoc:
 encrypt:
   aes:
     key: ${AES_ENCRYPTION_KEY}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,20 @@ apple:
     token: https://appleid.apple.com
     public-key: https://appleid.apple.com/auth/keys
     revoke: https://appleid.apple.com/auth/revoke
+
+management:
+  endpoints:
+    web:
+      base-path: /actuator
+
+  endpoint:
+    health:
+      show-details: never
+      probes:
+        enabled: true
+      group:
+        liveness:
+          include: ping
+        readiness:
+          include: db, redis
+


### PR DESCRIPTION
## 🔀 변경 내용
서버의 상태를 즉시 반환할 수 있는 가벼운 헬스체크 API를 추가하였습니다.

## ✅ 작업 항목
- [x] `GET /health/readiness`
- [x] `GET /health/liveness`
- [x] Swagger에 설명 추가
- [x] `SecurityConfig`에서 `/health/**`, `/actuator/health/**` 로그인 없이 접근 추가

## 📸 스크린샷 (선택)
- `GET /health/readiness`: DB와 redis 상태 check API
<img width="694" height="479" alt="Image" src="https://github.com/user-attachments/assets/1c0b188c-a17f-4ea8-a059-7da1ad185aa0" />

- `GET /health/liveness`: application 상태 check API
<img width="1091" height="313" alt="Image" src="https://github.com/user-attachments/assets/28f46ee7-6f65-4f50-95f4-592f6fb99e39" />

## 📎 참고 이슈
#140 
[\[OFFNAL-25\]](https://shifterz.atlassian.net/browse/OFFNAL-25?atlOrigin=eyJpIjoiY2JmY2QzZjNjZmRjNGFhYjkxYzVlYTJmYmIzOTY2ZTgiLCJwIjoiaiJ9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공개 상태 확인 엔드포인트 추가: 시스템의 건강 상태를 실시간으로 모니터링할 수 있도록 `/health/liveness` 및 `/health/readiness` 엔드포인트를 제공합니다. 이 엔드포인트들은 인증 없이 공개적으로 접근 가능하며, 시스템 전체 상태와 데이터베이스, Redis 등 주요 구성 요소들의 개별 상태 정보를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->