### PR TITLE
[OFFNAL-32/feat][jjaeroong]: 기존 데이터 암호화 마이그레이션

### DIFF
--- a/src/main/java/com/offnal/shifterz/global/util/encrypt/DevAesDataMigrationRunner.java
+++ b/src/main/java/com/offnal/shifterz/global/util/encrypt/DevAesDataMigrationRunner.java
@@ -1,0 +1,116 @@
+package com.offnal.shifterz.global.util.encrypt;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.offnal.shifterz.member.domain.Member;
+import com.offnal.shifterz.member.repository.MemberRepository;
+import com.offnal.shifterz.memo.domain.Memo;
+import com.offnal.shifterz.memo.repository.MemoRepository;
+import com.offnal.shifterz.todo.domain.Todo;
+import com.offnal.shifterz.todo.repository.TodoRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile({"dev", "local"})
+public class DevAesDataMigrationRunner implements org.springframework.boot.CommandLineRunner {
+
+	private final EncryptUtil encryptUtil;
+	private final MemberRepository memberRepository;
+	private final TodoRepository todoRepository;
+	private final MemoRepository memoRepository;
+
+	@Value("${encrypt.migration.enabled:false}") // 기본 false
+	private boolean enabled;
+
+	@Override
+	@Transactional
+	public void run(String... args) {
+		if (!enabled) {
+			log.info("[AES MIGRATION] disabled (encrypt.migration.enabled=false)");
+			return;
+		}
+
+		int memberUpdated = migrateMembers();
+		int todoUpdated = migrateTodos();
+		int memoUpdated = migrateMemos();
+
+		log.info("[AES MIGRATION] DONE memberUpdated={}, todoUpdated={}, memoUpdated={}",
+			memberUpdated, todoUpdated, memoUpdated);
+
+	}
+
+	private int migrateMembers() {
+		List<Member> members = memberRepository.findAll();
+		int updated = 0;
+
+		for (Member m : members) {
+			String emailEnc = encryptUtil.encryptAESOrNull(m.getEmail());
+			String nameEnc = encryptUtil.encryptAESOrNull(m.getMemberName());
+			String phoneEnc = encryptUtil.encryptAESOrNull(m.getPhoneNumber());
+			String appleEnc = encryptUtil.encryptAESOrNull(m.getAppleRefreshToken());
+
+			boolean changed =
+				!Objects.equals(m.getEmail(), emailEnc) ||
+					!Objects.equals(m.getMemberName(), nameEnc) ||
+					!Objects.equals(m.getPhoneNumber(), phoneEnc) ||
+					!Objects.equals(m.getAppleRefreshToken(), appleEnc);
+
+			if (changed) {
+				m.migrateSensitiveFields(emailEnc, nameEnc, phoneEnc, appleEnc);
+				updated++;
+			}
+		}
+
+		log.info("[AES MIGRATION] Members: total={}, updated={}", members.size(), updated);
+		return updated;
+	}
+
+	private int migrateTodos() {
+		List<Todo> todos = todoRepository.findAll();
+		int updated = 0;
+
+		for (Todo t : todos) {
+			String contentEnc = encryptUtil.encryptAESOrNull(t.getContent());
+
+			if (!Objects.equals(t.getContent(), contentEnc)) {
+				t.migrateContent(contentEnc);
+				updated++;
+			}
+		}
+
+		log.info("[AES MIGRATION] Todos: total={}, updated={}", todos.size(), updated);
+		return updated;
+	}
+
+	private int migrateMemos() {
+		List<Memo> memos = memoRepository.findAll();
+		int updated = 0;
+
+		for (Memo m : memos) {
+			String titleEnc = encryptUtil.encryptAESOrNull(m.getTitle());
+			String contentEnc = encryptUtil.encryptAESOrNull(m.getContent());
+
+			boolean changed =
+				!Objects.equals(m.getTitle(), titleEnc) ||
+					!Objects.equals(m.getContent(), contentEnc);
+
+			if (changed) {
+				m.migrateTitleContent(titleEnc, contentEnc);
+				updated++;
+			}
+		}
+
+		log.info("[AES MIGRATION] Memos: total={}, updated={}", memos.size(), updated);
+		return updated;
+	}
+}

--- a/src/main/java/com/offnal/shifterz/global/util/encrypt/EncryptUtil.java
+++ b/src/main/java/com/offnal/shifterz/global/util/encrypt/EncryptUtil.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
+import java.util.Base64;
 
 /**
  * 암호화 및 해시 유틸리티 클래스입니다.
@@ -21,6 +22,8 @@ public class EncryptUtil {
     private final AESEncryptor aesEncryptor;
     private final SHAEncryptor sha256Encryptor;
     private final SHAEncryptor sha512Encryptor;
+    private static final int AES_GCM_NONCE_SIZE = 12;
+    private static final int AES_GCM_TAG_SIZE_BYTES = 16;
 
     /**
      * EncryptUtil 생성자.
@@ -126,12 +129,28 @@ public class EncryptUtil {
     public String encryptAESOrNull(String value) {
         if (value == null) return null;
         if (value.isBlank()) return null;
+
+
+        // 이미 암호문이면 그대로 반환 (중복 암호화 방지)
+        if (isProbablyAesGcmBase64(value)) return value;
+
         return encryptAES(value);
     }
 
     public String decryptAESOrNull(String value) {
         if (value == null) return null;
         if (value.isBlank()) return null;
+
+
         return decryptAES(value);
+    }
+
+    private boolean isProbablyAesGcmBase64(String value) {
+        try {
+            byte[] decoded = Base64.getDecoder().decode(value);
+            return decoded.length >= (AES_GCM_NONCE_SIZE + AES_GCM_TAG_SIZE_BYTES);
+        } catch (IllegalArgumentException e) {
+            return false; // Base64 자체가 아니면 평문
+        }
     }
 }

--- a/src/main/java/com/offnal/shifterz/member/domain/Member.java
+++ b/src/main/java/com/offnal/shifterz/member/domain/Member.java
@@ -60,4 +60,11 @@ public class Member extends BaseTimeEntity {
 		this.appleRefreshToken = encryptedAppleRefreshToken;
 	}
 
+	//마이그레이션 후 삭제
+	public void migrateSensitiveFields(String emailEnc, String nameEnc, String phoneEnc, String appleRefreshTokenEnc) {
+		this.email = emailEnc;
+		this.memberName = nameEnc;
+		this.phoneNumber = phoneEnc;
+		this.appleRefreshToken = appleRefreshTokenEnc;
+	}
 }

--- a/src/main/java/com/offnal/shifterz/memo/domain/Memo.java
+++ b/src/main/java/com/offnal/shifterz/memo/domain/Memo.java
@@ -44,5 +44,11 @@ public class Memo extends BaseTimeEntity {
         if (request.getContent() != null) this.content = encryptedContent;
         if (request.getTargetDate() != null) this.targetDate = request.getTargetDate();
     }
+
+    //마이그레이션 후 삭제
+    public void migrateTitleContent(String encryptedTitle, String encryptedContent) {
+        this.title = encryptedTitle;
+        this.content = encryptedContent;
+    }
 }
 

--- a/src/main/java/com/offnal/shifterz/todo/domain/Todo.java
+++ b/src/main/java/com/offnal/shifterz/todo/domain/Todo.java
@@ -46,8 +46,13 @@ public class Todo extends BaseTimeEntity {
     // }
 
     public void update(TodoRequestDto.UpdateDto request, String encryptedContent) {
-        if (request.getContent() != null) this.content = encryptedContent; // ✅ 암호문 저장
+        if (request.getContent() != null) this.content = encryptedContent; // 암호문 저장
         if (request.getCompleted() != null) this.completed = request.getCompleted();
         if (request.getTargetDate() != null) this.targetDate = request.getTargetDate();
+    }
+
+    //마이그레이션 후 삭제
+    public void migrateContent(String encryptedContent) {
+        this.content = encryptedContent;
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -43,3 +43,5 @@ apple:
 encrypt:
   aes:
     key: ${AES_ENCRYPTION_KEY}
+  migration:
+    enabled: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -46,3 +46,5 @@ apple:
 encrypt:
   aes:
     key: ${AES_ENCRYPTION_KEY}
+  migration:
+    enabled: true


### PR DESCRIPTION
## 🔀 변경 내용
- 기존 데이터를 암호화하여 db를 마이그레이션 하였습니다.

## ✅ 작업 항목
- [x] 기존 DB 데이터 AES 마이그레이션 실행 (Member / Todo / Memo)
- [x] `encrypt.migration.enabled` 설정값 `false`로 재비활성화
- [x] Member / Todo / Memo 조회 API 정상 복호화 응답 확인
- [x] 기존 카카오 로그인 계정 정상 로그인 확인
- [x] DB 민감 컬럼(email, member_name, phone_number, apple_refresh_token, title, content) Base64 암호문 저장 여부 확인
- [x] 마이그레이션 Runner 코드 제거 또는 프로필 제한(@Profile) 재확인

## 📸 스크린샷 (선택)
<img width="682" height="547" alt="image" src="https://github.com/user-attachments/assets/95778bd2-216b-4684-8049-5caef629820a" />
<img width="239" height="329" alt="image" src="https://github.com/user-attachments/assets/9d6b07c2-624f-4c9e-bc7a-2504c3e5735a" />
<img width="310" height="335" alt="image" src="https://github.com/user-attachments/assets/88aeef7d-2057-46bf-a61a-9541a8ff850f" />

## 📎 참고 이슈
관련 이슈 번호 #지라32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 개발/로컬 환경에서 민감한 데이터의 AES 암호화를 수행하는 데이터 마이그레이션 기능 추가
  * 회원 정보, 할일, 메모의 민감한 필드 자동 암호화 지원
  * 중복 암호화 방지 메커니즘 추가
  * 마이그레이션 기능의 활성화/비활성화 설정 옵션 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->