### PR TITLE
OFFNAL-79 백엔드 통신 프로토콜 변경 및 API 수정

### DIFF
--- a/src/main/java/com/offnal/shifterz/log/LogAop.java
+++ b/src/main/java/com/offnal/shifterz/log/LogAop.java
@@ -74,7 +74,10 @@ public class LogAop {
     @AfterThrowing(value = "controllerPointcut() || servicePointcut()", throwing = "ex")
     public void logException(JoinPoint joinPoint, Exception ex) {
         Method method = ((MethodSignature) joinPoint.getSignature()).getMethod();
-        Member member = AuthService.getCurrentMember();
+        Member member = null;
+        try {
+            member = AuthService.getCurrentMember();
+        } catch (Exception ignored) {}
 
         String msg = "[Error] in " + method.getName() + " - " + ex.getMessage();
 

--- a/src/main/java/com/offnal/shifterz/oauth/LoginService.java
+++ b/src/main/java/com/offnal/shifterz/oauth/LoginService.java
@@ -11,6 +11,7 @@ import com.offnal.shifterz.oauth.apple.AppleAuthTokenResponse;
 import com.offnal.shifterz.oauth.apple.AppleLoginRequest;
 import com.offnal.shifterz.oauth.apple.AppleService;
 import com.offnal.shifterz.oauth.apple.AppleUserInfoResponseDto;
+import com.offnal.shifterz.oauth.kakao.KakaoLoginRequest;
 import com.offnal.shifterz.oauth.kakao.KakaoService;
 import com.offnal.shifterz.oauth.kakao.KakaoUserInfoResponseDto;
 import lombok.AllArgsConstructor;
@@ -106,6 +107,11 @@ public class LoginService {
         String jwtRefreshToken = jwtTokenProvider.createRefreshToken(result.getId());
 
         return AuthResponseDto.from(result, jwtAccessToken, jwtRefreshToken);
+    }
+
+    public AuthResponseDto loginWithKakaoNative(KakaoLoginRequest request) {
+        KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(request.getAccessToken());
+        return handleKakaoLogin(userInfo);
     }
 
     @Getter

--- a/src/main/java/com/offnal/shifterz/oauth/LoginService.java
+++ b/src/main/java/com/offnal/shifterz/oauth/LoginService.java
@@ -110,7 +110,12 @@ public class LoginService {
     }
 
     public AuthResponseDto loginWithKakaoNative(KakaoLoginRequest request) {
-        KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(request.getAccessToken());
+        KakaoUserInfoResponseDto userInfo;
+        try {
+            userInfo = kakaoService.getUserInfo(request.getAccessToken());
+        } catch (Exception e) {
+            throw new CustomException(LoginErrorCode.INVALID_SOCIAL_TOKEN);
+        }
         return handleKakaoLogin(userInfo);
     }
 

--- a/src/main/java/com/offnal/shifterz/oauth/OauthLoginController.java
+++ b/src/main/java/com/offnal/shifterz/oauth/OauthLoginController.java
@@ -10,6 +10,7 @@ import com.offnal.shifterz.global.util.AuthResponseUtil;
 import com.offnal.shifterz.member.domain.Provider;
 import com.offnal.shifterz.member.dto.AuthResponseDto;
 import com.offnal.shifterz.oauth.apple.AppleLoginRequest;
+import com.offnal.shifterz.oauth.kakao.KakaoLoginRequest;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -162,5 +163,17 @@ public class OauthLoginController {
         return SuccessResponse.success(SuccessCode.LOGIN_SUCCESS, response);
     }
 
-
+    @Operation(
+            summary = "카카오 로그인 (네이티브)",
+            description = """
+                     Kakao Native SDK를 통해 획득한 accessToken을 이용하여 카카오 로그인 또는 신규 회원가입을 처리하는 API입니다.
+                    """
+    )
+    @PostMapping("/login/kakao")
+    public SuccessResponse<AuthResponseDto> kakaoNativeLogin(
+            @RequestBody KakaoLoginRequest request
+    ){
+        AuthResponseDto response = loginService.loginWithKakaoNative(request);
+        return SuccessResponse.success(SuccessCode.LOGIN_SUCCESS, response);
+    }
 }

--- a/src/main/java/com/offnal/shifterz/oauth/OauthLoginController.java
+++ b/src/main/java/com/offnal/shifterz/oauth/OauthLoginController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -171,7 +172,7 @@ public class OauthLoginController {
     )
     @PostMapping("/login/kakao")
     public SuccessResponse<AuthResponseDto> kakaoNativeLogin(
-            @RequestBody KakaoLoginRequest request
+            @RequestBody @Valid KakaoLoginRequest request
     ){
         AuthResponseDto response = loginService.loginWithKakaoNative(request);
         return SuccessResponse.success(SuccessCode.LOGIN_SUCCESS, response);

--- a/src/main/java/com/offnal/shifterz/oauth/kakao/KakaoLoginRequest.java
+++ b/src/main/java/com/offnal/shifterz/oauth/kakao/KakaoLoginRequest.java
@@ -1,10 +1,12 @@
 package com.offnal.shifterz.oauth.kakao;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class KakaoLoginRequest {
+    @NotBlank(message = "accessToken은 필수입니다.")
     @Schema(description = "Kakao에서 받은 accessToken")
     private String accessToken;
 }

--- a/src/main/java/com/offnal/shifterz/oauth/kakao/KakaoLoginRequest.java
+++ b/src/main/java/com/offnal/shifterz/oauth/kakao/KakaoLoginRequest.java
@@ -1,0 +1,10 @@
+package com.offnal.shifterz.oauth.kakao;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class KakaoLoginRequest {
+    @Schema(description = "Kakao에서 받은 accessToken")
+    private String accessToken;
+}


### PR DESCRIPTION
## 🔀 변경 내용        
 - 카카오 로그인 방식을 WebView(Callback) 방식에서 Native SDK 방식으로 수정
 - 기존 `/callback` 엔드포인트는 유지 (개발 서버에서 정상 연동 확인 후 삭제 예정)
 - Native SDK에서 발급받은 accessToken을 직접 수신·검증하여 자체 JWT를 발급하는 API 추가
                                                                                        
  ## ✅ 작업 항목
  - [x] `POST /login/kakao` Native SDK 전용 로그인 엔드포인트 추가                                                         
  - [x] `KakaoLoginRequest` DTO 생성 (accessToken 수신)
  - [x] `LoginService.loginWithKakaoNative()` 구현. (Kakao API로 accessToken 검증 후    
  자체 JWT 발급)
  - [x] `LogAop` 버그 수정 (비인증 요청에서 예외 발생)
  - [x] 테스트 완료 (Kakao accessToken → 사용자 정보 조회 → JWT 발급 확인)
                              

## 📸 스크린샷 (선택)
<img width="930" height="243" alt="스크린샷 2026-04-04 오후 10 36 14" src="https://github.com/user-attachments/assets/b0703979-45da-49e1-af7a-5bc73798feea" />

## 📎 참고 이슈
[OFFNAL-79](https://shifterz.atlassian.net/issues?filter=-1&selectedIssue=OFFNAL-79)

[OFFNAL-79]: https://shifterz.atlassian.net/browse/OFFNAL-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Kakao 네이티브 로그인 기능 추가. 사용자는 Kakao 액세스 토큰을 통해 직접 로그인할 수 있습니다.

* **Bug Fixes**
  * 예외 로깅 시스템의 안정성 개선. 현재 사용자 정보 조회 실패 시에도 로깅이 정상적으로 진행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->